### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,11 +2,11 @@
 buildifier: latest
 tasks:
   ubuntu_default_compiler:
-    platform: ubuntu1604
+    platform: ubuntu1804
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   #ubuntu_clang:
   #  platform: ubuntu1604
   #  environment:


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.